### PR TITLE
Fix DateTimeFormatter-Exception when parsing date.

### DIFF
--- a/src/main/kotlin/devcsrj/mvnrepository/ArtifactSearchEntriesPage.kt
+++ b/src/main/kotlin/devcsrj/mvnrepository/ArtifactSearchEntriesPage.kt
@@ -58,7 +58,7 @@ internal class ArtifactSearchEntriesPage {
             override fun convert(root: Element?, selector: Selector): LocalDate? {
                 val node = root?.selectFirst(selector.value)?.text() ?: return null
                 val str = node.substringAfter(PREFIX)
-                return LocalDate.parse(str, DateTimeFormatter.ofPattern("MMM d, yyyy"))
+                return LocalDate.parse(date, DateTimeFormatter.ofPattern("MMM d, uuuu", Locale.ENGLISH))
             }
 
         }

--- a/src/main/kotlin/devcsrj/mvnrepository/ArtifactSearchEntriesPage.kt
+++ b/src/main/kotlin/devcsrj/mvnrepository/ArtifactSearchEntriesPage.kt
@@ -58,7 +58,7 @@ internal class ArtifactSearchEntriesPage {
             override fun convert(root: Element?, selector: Selector): LocalDate? {
                 val node = root?.selectFirst(selector.value)?.text() ?: return null
                 val str = node.substringAfter(PREFIX)
-                return LocalDate.parse(date, DateTimeFormatter.ofPattern("MMM d, uuuu", Locale.ENGLISH))
+                return LocalDate.parse(str, DateTimeFormatter.ofPattern("MMM d, uuuu", Locale.ENGLISH))
             }
 
         }


### PR DESCRIPTION
Before a DateTimeFormatter-Exception was thrown due to no Locale declaration in the parameter. The exact reason remains unknown.
Whatsoever, Locale.ENGLISH is given as a parameter now as we relate to mvnrepository here, who use english DateTime formats.